### PR TITLE
stack.set_param should rewrite currently nil params to empty string

### DIFF
--- a/lib/pryaws/cloud-formation.rb
+++ b/lib/pryaws/cloud-formation.rb
@@ -25,6 +25,7 @@ module AWS
         p = parameters()
         raise "Invalid param '#{key}'." if p[key].nil?
         p[key] = value
+        p = Hash[*p.map{|k,v| [k, v || ""]}.flatten]
         update :template => template, :parameters => p, :capabilities => ['CAPABILITY_IAM']
       end
 


### PR DESCRIPTION
If some params are already nil, trying to set_param fails because amazon rejects the nil params in the hash. This writes all nil values in the hash to an empty string. map! would have been nice but is on enumerable, not hash, and won't return a hash. This way seems to work easiest.
