### PR TITLE
gem 'aws' is not actually an official aws gem, and isnt being used

### DIFF
--- a/lib/pryaws/auto-scaling.rb
+++ b/lib/pryaws/auto-scaling.rb
@@ -1,4 +1,3 @@
-require 'aws'
 require 'aws-sdk'
 
 module AWS

--- a/lib/pryaws/cloud-formation.rb
+++ b/lib/pryaws/cloud-formation.rb
@@ -1,4 +1,3 @@
-require 'aws'
 require 'aws-sdk'
 
 module AWS

--- a/lib/pryaws/ec2.rb
+++ b/lib/pryaws/ec2.rb
@@ -1,4 +1,3 @@
-require 'aws'
 require 'aws-sdk'
 
 module AWS

--- a/lib/pryaws/sns.rb
+++ b/lib/pryaws/sns.rb
@@ -1,4 +1,3 @@
-require 'aws'
 require 'aws-sdk'
 
 module AWS


### PR DESCRIPTION
fresh rbenv
gem install pryaws
pryaws
[error requiring 'aws']
look at rubygems, oh aws isnt an official gem. only aws-sdk is.
we use aws-sdk, but we dont use anything from aws, we just require it.
delete requires.
???
profit.
